### PR TITLE
 Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Accounting [![Build Status](https://api.travis-ci.com/apache/fineract-cn-accounting.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-accounting) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-accounting)](https://hub.docker.com/r/apache/fineract-cn-accounting/builds)
+# Apache Fineract CN Accounting [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-accounting)](https://hub.docker.com/r/apache/fineract-cn-accounting/builds)
 
 The accounting service tracks journal entries in accounts, and accounts in ledgers.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-accounting).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.